### PR TITLE
Edit .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -30,7 +30,6 @@ ColumnLimit: 80
 PointerAlignment: Right
 ReferenceAlignment: Right
 AlignAfterOpenBracket: Align
-AlignArrayOfStructures: Left
 AlignConsecutiveAssignments: false # Visual appeal
 # Macros
 AlignConsecutiveMacros:
@@ -50,7 +49,7 @@ AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: false
 AllowShortEnumsOnASingleLine: false
-AllowShortIfStatementsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse # Prevent reformatting of else switch
 AllowShortLoopsOnASingleLine: false
 BinPackParameters: false
 

--- a/.clang-format
+++ b/.clang-format
@@ -9,8 +9,11 @@ Standard: Auto
 # ------------ PERSONAL PREFERANCE ------------ #
 IndentCaseLabels: true
 AlignArrayOfStructures: Left
+MaxEmptyLinesToKeep: 1
 
-
+# Includes
+SortIncludes: CaseInsensitive
+IncludeBlocks: Regroup
 
 # ------------- REQUIRED SETTINGS ------------- #
 
@@ -22,7 +25,6 @@ LineEnding: LF
 
 # Line management
 ColumnLimit: 80
-InsertNewlineAtEOF: true
 
 # General Alignment
 PointerAlignment: Right
@@ -65,13 +67,8 @@ BraceWrapping:
 BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: true
 
-# Includes
-SortIncludes: CaseInsensitive
-IncludeBlocks: Regroup
-
 # Misc
 DerivePointerBinding: false
-MaxEmptyLinesToKeep: 1
 
 # Spacing
 SpaceAfterCStyleCast: true


### PR DESCRIPTION
Tiny changes to .clang-format
- Remove InsertNewLineAtEOF
- Move Includes and MaxLinesToKeep to personal preference.